### PR TITLE
Polish UI: copy, layout, accessibility, and theming

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,7 +3,7 @@
 This file provides guidance to WARP (warp.dev) when working with code in this repository.
 
 ## Project overview
-Textonom is an Electron + React + TypeScript desktop app for local text transformations. It uses `electron-vite` for main/preload/renderer builds and `electron-builder` for packaging and release publishing.
+Textonom is an Electron + Vue 3 + TypeScript desktop app for local text transformations. It uses `electron-vite` for main/preload/renderer builds and `electron-builder` for packaging and release publishing.
 
 ## Canonical development commands
 Run from repository root.
@@ -45,15 +45,14 @@ There is currently no test runner configured in `package.json` (no `test` script
   - Creates frameless `BrowserWindow`, restores window position/size, manages update events, and owns IPC handlers.
   - Persists state files under Electron `userData/state`.
 - `src/preload/index.ts`: secure bridge (`window.api`) exposing IPC-backed methods to renderer (window controls, state persistence, updater).
-- `src/renderer/src/*`: React app UI and transformation engine.
+- `src/renderer/src/*`: Vue 3 app UI and transformation engine.
 
 ### State and persistence model
-- Active app state is in Zustand stores under `src/renderer/src/stores/`.
-  - Persisted stores: `settingsStore`, `tabsStore`, `homePageStore`, `windowStore`.
+- Active app state is in Pinia stores under `src/renderer/src/stores/`.
+  - Persisted stores: `settingsStore`, `tabsStore`, `homePageStore`, `windowStore`, `uiStore`.
   - Non-persisted in-memory store: `tabsContentStore` (tab input/output/params while app runs).
-- Legacy context/service code still exists under `src/renderer/src/contexts/*` and `src/renderer/src/services/{stateService,persistenceService}.ts`, but current app flow uses Zustand stores.
 - Persistence path:
-  - Store `persist` middleware -> `createElectronStorage` (`stores/electronStorage.ts`) -> `window.api.saveState/loadState` -> IPC handlers in `src/main/index.ts` -> JSON files in `userData/state/{key}.json`.
+  - Each store wires `setupPersistence` (`stores/electronStorage.ts`) -> `window.api.saveState/loadState` -> IPC handlers in `src/main/index.ts` -> JSON files in `userData/state/{key}.json`.
 - Main process separately tracks window geometry/fullscreen/maximized state and pushes updates back to renderer via `window-state-updated`.
 
 ### Transformation system wiring

--- a/README.md
+++ b/README.md
@@ -40,10 +40,11 @@ Helps make your sensitive data safe.
 
 Textonom is built with:
 
-- **Electron**: Cross-platform desktop application framework (v35.x.x)
-- **React**: UI library for building the user interface (v19.x.x)
-- **TypeScript**: Type-safe JavaScript (v5.x.x)
-- **Zustand**: State management
+- **Electron**: Cross-platform desktop application framework
+- **Vue 3**: UI framework (Composition API + `<script setup>`)
+- **TypeScript**: Type-safe JavaScript
+- **Pinia**: State management
+- **electron-vite**: Dev/build tooling
 - **electron-updater**: Auto-update functionality
 - **CSS**: Styling with custom themes (light, dark and cyberpunk)
 

--- a/src/renderer/src/components/About.vue
+++ b/src/renderer/src/components/About.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { ref, onMounted } from 'vue'
+import { getAllCategories } from '../transformations/registry'
 import './About.css'
 
 defineProps<{
@@ -7,6 +8,17 @@ defineProps<{
 }>()
 
 const appVersion = ref<string>('Unknown')
+
+const featureCategories = getAllCategories().map((c) => ({
+  name: c.name,
+  count: c.transformations.length
+}))
+
+const onOverlayClick = (e: MouseEvent, onClose: () => void): void => {
+  if ((e.target as HTMLElement).className === 'about-overlay') {
+    onClose()
+  }
+}
 
 onMounted(async () => {
   try {
@@ -18,11 +30,11 @@ onMounted(async () => {
 </script>
 
 <template>
-  <div class="about-overlay">
+  <div class="about-overlay" @click="(e) => onOverlayClick(e, onClose)">
     <div class="about-container">
       <div class="about-header">
         <h2>About Textonom</h2>
-        <button class="close-button" @click="onClose">✕</button>
+        <button class="close-button" aria-label="Close" @click="onClose">✕</button>
       </div>
 
       <div class="about-content">
@@ -38,16 +50,9 @@ onMounted(async () => {
         <div class="about-section">
           <h3>Features</h3>
           <ul>
-            <li>Base64 encoding/decoding</li>
-            <li>JSON formatting and minification</li>
-            <li>URL encoding/decoding</li>
-            <li>Case conversion</li>
-            <li>XML formatting</li>
-            <li>Line operations</li>
-            <li>HTML encoding/decoding</li>
-            <li>Cryptographic hashing</li>
-            <li>Format conversion (JSON/YAML)</li>
-            <li>And more...</li>
+            <li v-for="cat in featureCategories" :key="cat.name">
+              {{ cat.name }} ({{ cat.count }})
+            </li>
           </ul>
         </div>
 
@@ -72,10 +77,7 @@ onMounted(async () => {
 
         <div class="about-section">
           <h3>License</h3>
-          <p>
-            This software is open source and available under the Apache License Version 2.0
-            license.
-          </p>
+          <p>This software is open source and available under the MIT License.</p>
         </div>
       </div>
     </div>

--- a/src/renderer/src/components/HomePage.css
+++ b/src/renderer/src/components/HomePage.css
@@ -92,8 +92,12 @@
 
 .transformation-card:hover {
   transform: translateY(-2px);
-  /* box-shadow removed */
   border-color: var(--primary);
+}
+
+.transformation-card:focus-visible {
+  outline: 2px solid var(--primary);
+  outline-offset: 2px;
 }
 
 .transformation-card-open {
@@ -116,21 +120,32 @@
   border-radius: 4px;
   font-size: 0.7rem;
   font-weight: bold;
-  /* box-shadow removed */
   z-index: 1;
+}
+
+.transformation-card-content {
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+/* Reserve space for the open badge so long titles don't run underneath. */
+.transformation-card-open .transformation-card-content {
+  padding-right: 64px;
 }
 
 .transformation-title {
   font-size: 1.2rem;
-  margin-bottom: 0.5rem;
+  margin: 0;
   color: var(--text);
-  padding: 1rem 1rem 0.5rem 1rem;
 }
 
 .transformation-description {
   font-size: 0.9rem;
+  margin: 0;
   color: var(--text);
-  padding: 0 1rem 1rem 1rem;
+  opacity: 0.8;
 }
 
 .no-results {

--- a/src/renderer/src/components/HomePage.vue
+++ b/src/renderer/src/components/HomePage.vue
@@ -19,8 +19,17 @@ const { homePage } = storeToRefs(homePageStore)
 const { setHomePageSearchQuery, setHomePageScrollPosition } = homePageStore
 
 const homePageRef = ref<HTMLDivElement | null>(null)
+const searchInputRef = ref<HTMLInputElement | null>(null)
 
 const categories = getAllCategories()
+
+const handleKeydown = (e: KeyboardEvent): void => {
+  if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === 'k') {
+    e.preventDefault()
+    searchInputRef.value?.focus()
+    searchInputRef.value?.select()
+  }
+}
 
 const isTransformationOpen = (transformationId: string): boolean => {
   return tabs.value.some((tab) => tab.transformationId === transformationId)
@@ -59,12 +68,14 @@ onMounted(() => {
     homePageRef.value.scrollTop = homePage.value.scrollPosition
     homePageRef.value.addEventListener('scroll', handleScroll)
   }
+  window.addEventListener('keydown', handleKeydown)
 })
 
 onUnmounted(() => {
   if (homePageRef.value) {
     homePageRef.value.removeEventListener('scroll', handleScroll)
   }
+  window.removeEventListener('keydown', handleKeydown)
 })
 </script>
 
@@ -75,9 +86,11 @@ onUnmounted(() => {
 
       <div class="search-container">
         <input
+          ref="searchInputRef"
           type="text"
           class="search-input"
-          placeholder="Search transformations..."
+          placeholder="Search transformations… (Ctrl+K)"
+          aria-label="Search transformations"
           :value="homePage.searchQuery"
           @input="handleSearchChange"
         />
@@ -85,11 +98,7 @@ onUnmounted(() => {
     </div>
 
     <div class="categories-container">
-      <div
-        v-for="category in filteredCategories"
-        :key="category.id"
-        class="category-section"
-      >
+      <div v-for="category in filteredCategories" :key="category.id" class="category-section">
         <h2 class="category-title">{{ category.name }}</h2>
         <p class="category-description">{{ category.description }}</p>
 
@@ -99,7 +108,12 @@ onUnmounted(() => {
             :key="transformation.id"
             class="transformation-card"
             :class="{ 'transformation-card-open': isTransformationOpen(transformation.id) }"
+            role="button"
+            tabindex="0"
+            :aria-pressed="isTransformationOpen(transformation.id)"
             @click="handleTransformationClick(transformation.id)"
+            @keydown.enter.prevent="handleTransformationClick(transformation.id)"
+            @keydown.space.prevent="handleTransformationClick(transformation.id)"
           >
             <div class="transformation-card-content">
               <h3 class="transformation-title">{{ transformation.name }}</h3>

--- a/src/renderer/src/components/Settings.css
+++ b/src/renderer/src/components/Settings.css
@@ -25,21 +25,20 @@
   padding: 0;
   box-shadow: 0 5px 15px rgba(0, 0, 0, 0.3);
   border: 1px solid var(--border);
+  position: relative;
 }
 
 .settings-header {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding-bottom: 0.5rem;
   border-bottom: 1px solid var(--border);
-  position: sticky;
-  top: 0;
   background-color: var(--surface);
   z-index: 10;
   width: 100%;
-  padding: 1rem 1rem 0.5rem;
+  padding: 1rem 1rem 0.75rem;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  flex-shrink: 0;
 }
 
 .settings-header h2 {
@@ -86,7 +85,13 @@
 .settings-nav-item {
   padding: 12px 16px;
   cursor: pointer;
+  background: transparent;
+  border: none;
   border-bottom: 1px solid var(--border);
+  color: var(--text);
+  text-align: left;
+  width: 100%;
+  font: inherit;
   transition: background-color 0.2s;
   white-space: nowrap;
   overflow: hidden;
@@ -109,26 +114,25 @@
 
 .settings-sections-container {
   flex: 1;
-  overflow-y: hidden;
+  overflow: hidden;
   padding: 0;
   position: relative;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
 }
 
 .settings-section {
   padding: 0;
-  position: absolute;
-  top: 0;
-  left: 0;
   width: 100%;
-  height: 100%;
+  flex: 1;
   display: flex;
   flex-direction: column;
   overflow: hidden;
+  min-height: 0;
 }
 
 .settings-section-title {
-  position: sticky;
-  top: 0;
   background-color: var(--surface);
   padding: 12px 16px;
   margin: 0;
@@ -139,35 +143,41 @@
   /* Fixed height to match nav items */
   display: flex;
   align-items: center;
+  flex-shrink: 0;
 }
 
 .settings-section-content {
   padding: 16px;
   overflow-y: auto;
   flex: 1;
+  min-height: 0;
 }
 
 .settings-row {
-  display: flex;
-  margin-bottom: 0.5rem;
+  display: grid;
+  grid-template-columns: 220px 1fr;
+  gap: 12px;
+  margin-bottom: 0.75rem;
   align-items: center;
 }
 
 .settings-label {
-  flex: 1;
-  margin-right: 16px;
+  margin: 0;
 }
 
 .settings-control {
-  flex: 2;
   display: flex;
   align-items: center;
+  gap: 8px;
+  min-width: 0;
 }
 
 .settings-control select,
-.settings-control input[type='number'] {
+.settings-control input[type='number'],
+.settings-control input[type='text'] {
   width: 100%;
-  max-width: 300px;
+  max-width: 320px;
+  min-width: 0;
 }
 
 .settings-description {
@@ -180,7 +190,6 @@
 .settings-control input[type='text'],
 .settings-control input[type='number'],
 .settings-control select {
-  flex: 1;
   padding: 8px;
   border: 1px solid var(--border);
   border-radius: 4px;
@@ -191,40 +200,98 @@
 .settings-control input[type='checkbox'] {
   width: 16px;
   height: 16px;
+  margin: 0;
+  cursor: pointer;
 }
 
 .settings-footer {
   display: flex;
   justify-content: flex-end;
   gap: 0.5rem;
-  padding: 0.5rem 1rem 1rem;
+  padding: 0.75rem 1rem;
   border-top: 1px solid var(--border);
   background-color: var(--surface);
   margin-top: auto;
+  flex-shrink: 0;
 }
 
 .settings-footer button {
   padding: 8px 16px;
-  border: none;
+  border: 1px solid var(--border);
   border-radius: 4px;
   cursor: pointer;
   font-size: 14px;
+}
+
+.settings-footer .btn-primary {
   background-color: var(--primary);
   color: var(--buttonText);
+  border-color: var(--primary);
+}
+
+.settings-footer .btn-secondary {
+  background-color: transparent;
+  color: var(--text);
 }
 
 .settings-footer button:hover {
   opacity: 0.9;
 }
 
-.settings-footer button:first-child {
-  background-color: var(--secondary);
+.settings-confirm-overlay {
+  position: absolute;
+  inset: 0;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 20;
+}
+
+.settings-confirm {
+  background-color: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 1rem 1.25rem;
+  max-width: 360px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+}
+
+.settings-confirm p {
+  margin: 0 0 1rem;
+  color: var(--text);
+}
+
+.settings-confirm-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+}
+
+.settings-confirm-actions button {
+  padding: 6px 14px;
+  border-radius: 4px;
+  border: 1px solid var(--border);
+  cursor: pointer;
+  font-size: 14px;
+}
+
+.settings-confirm-actions .btn-primary {
+  background-color: var(--primary);
+  color: var(--buttonText);
+  border-color: var(--primary);
+}
+
+.settings-confirm-actions .btn-secondary {
+  background-color: transparent;
+  color: var(--text);
 }
 
 .settings-info {
-  margin-top: 8px;
+  margin-top: 12px;
   font-size: 0.9em;
-  color: var(--textSecondary);
+  color: var(--text);
+  opacity: 0.7;
   max-width: 500px;
 }
 

--- a/src/renderer/src/components/Settings.vue
+++ b/src/renderer/src/components/Settings.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import { ref, reactive, watch } from 'vue'
+import { ref, computed } from 'vue'
+import { storeToRefs } from 'pinia'
 import { useSettingsStore } from '../stores/settingsStore'
 import { THEMES } from '../styles/themes'
 import './Settings.css'
@@ -14,17 +15,8 @@ interface Section {
 }
 
 const settingsStore = useSettingsStore()
-const {
-  setTheme,
-  setFontSize,
-  setFontFamily,
-  setAutoUpdate,
-  setCheckForUpdatesOnStartup,
-  setCrtEffect,
-  setBcryptRounds,
-  setWordWrap,
-  resetSettings
-} = settingsStore
+const { settings } = storeToRefs(settingsStore)
+const { resetSettings } = settingsStore
 
 const sections: Section[] = [
   { id: 'theme', title: 'Theme' },
@@ -34,6 +26,7 @@ const sections: Section[] = [
 ]
 
 const activeSection = ref('theme')
+const showResetConfirm = ref(false)
 
 const fontOptions = [
   "Consolas, 'Courier New', monospace",
@@ -43,38 +36,48 @@ const fontOptions = [
   'monospace'
 ]
 
-const localSettings = reactive({
-  theme: settingsStore.settings.theme,
-  fontSize: settingsStore.settings.fontSize,
-  fontFamily: settingsStore.settings.fontFamily,
-  autoUpdate: settingsStore.settings.autoUpdate,
-  checkForUpdatesOnStartup: settingsStore.settings.checkForUpdatesOnStartup,
-  turboMode: settingsStore.settings.crtEffect,
-  bcryptRounds: settingsStore.settings.bcryptRounds || 12,
-  wordWrap: settingsStore.settings.wordWrap
+const theme = computed({
+  get: () => settings.value.theme,
+  set: (v) => (settings.value.theme = v)
+})
+const fontSize = computed({
+  get: () => settings.value.fontSize,
+  set: (v) => (settings.value.fontSize = Number(v))
+})
+const fontFamily = computed({
+  get: () => settings.value.fontFamily,
+  set: (v) => (settings.value.fontFamily = v)
+})
+const autoUpdate = computed({
+  get: () => settings.value.autoUpdate,
+  set: (v) => (settings.value.autoUpdate = v)
+})
+const checkForUpdatesOnStartup = computed({
+  get: () => settings.value.checkForUpdatesOnStartup,
+  set: (v) => (settings.value.checkForUpdatesOnStartup = v)
+})
+const turboMode = computed({
+  get: () => settings.value.crtEffect,
+  set: (v) => (settings.value.crtEffect = v)
+})
+const bcryptRounds = computed({
+  get: () => settings.value.bcryptRounds,
+  set: (v) => (settings.value.bcryptRounds = Number(v))
+})
+const wordWrap = computed({
+  get: () => settings.value.wordWrap,
+  set: (v) => (settings.value.wordWrap = v)
 })
 
-watch(() => localSettings.theme, (v) => setTheme(v))
-watch(() => localSettings.fontSize, (v) => setFontSize(Number(v)))
-watch(() => localSettings.fontFamily, (v) => setFontFamily(v))
-watch(() => localSettings.autoUpdate, (v) => setAutoUpdate(v))
-watch(() => localSettings.checkForUpdatesOnStartup, (v) => setCheckForUpdatesOnStartup(v))
-watch(() => localSettings.turboMode, (v) => setCrtEffect(v))
-watch(() => localSettings.bcryptRounds, (v) => setBcryptRounds(Number(v)))
-watch(() => localSettings.wordWrap, (v) => setWordWrap(v))
-
-const handleReset = (): void => {
-  if (window.confirm('Are you sure you want to reset all settings to their default values?')) {
-    resetSettings()
-    localSettings.theme = 'cyberpunk'
-    localSettings.fontSize = 14
-    localSettings.fontFamily = "Consolas, 'Courier New', monospace"
-    localSettings.autoUpdate = true
-    localSettings.checkForUpdatesOnStartup = true
-    localSettings.turboMode = true
-    localSettings.bcryptRounds = 12
-    localSettings.wordWrap = true
-  }
+const requestReset = (): void => {
+  showResetConfirm.value = true
+}
+const confirmReset = (): void => {
+  resetSettings()
+  showResetConfirm.value = false
+}
+const cancelReset = (): void => {
+  showResetConfirm.value = false
 }
 
 const onOverlayClick = (e: MouseEvent, onClose: () => void): void => {
@@ -86,24 +89,27 @@ const onOverlayClick = (e: MouseEvent, onClose: () => void): void => {
 
 <template>
   <div class="settings-overlay" @click="(e) => onOverlayClick(e, onClose)">
-    <div class="settings-container">
+    <div class="settings-container" role="dialog" aria-labelledby="settings-title">
       <div class="settings-header">
-        <h2>Settings</h2>
-        <button class="close-button" @click="onClose">✕</button>
+        <h2 id="settings-title">Settings</h2>
+        <button class="close-button" aria-label="Close settings" @click="onClose">✕</button>
       </div>
 
       <div class="settings-content">
         <div class="settings-layout">
-          <div class="settings-sidebar">
-            <div
+          <div class="settings-sidebar" role="tablist">
+            <button
               v-for="section in sections"
               :key="section.id"
+              type="button"
               class="settings-nav-item"
               :class="{ active: activeSection === section.id }"
+              role="tab"
+              :aria-selected="activeSection === section.id"
               @click="activeSection = section.id"
             >
               {{ section.title }}
-            </div>
+            </button>
           </div>
 
           <div class="settings-sections-container">
@@ -111,9 +117,9 @@ const onOverlayClick = (e: MouseEvent, onClose: () => void): void => {
               <h3 class="settings-section-title">Theme</h3>
               <div class="settings-section-content">
                 <div class="settings-row">
-                  <label class="settings-label">Theme</label>
+                  <label class="settings-label" for="setting-theme">Theme</label>
                   <div class="settings-control">
-                    <select v-model="localSettings.theme">
+                    <select id="setting-theme" v-model="theme">
                       <option :value="THEMES.LIGHT">Light</option>
                       <option :value="THEMES.DARK">Dark</option>
                       <option :value="THEMES.CYBERPUNK">Cyberpunk</option>
@@ -122,10 +128,9 @@ const onOverlayClick = (e: MouseEvent, onClose: () => void): void => {
                 </div>
 
                 <div class="settings-row">
-                  <label class="settings-label">Turbo Mode</label>
+                  <label class="settings-label" for="setting-turbo">Turbo Mode</label>
                   <div class="settings-control">
-                    <input v-model="localSettings.turboMode" type="checkbox" />
-                    <span class="settings-description">Enable</span>
+                    <input id="setting-turbo" v-model="turboMode" type="checkbox" />
                   </div>
                 </div>
 
@@ -141,9 +146,9 @@ const onOverlayClick = (e: MouseEvent, onClose: () => void): void => {
               <h3 class="settings-section-title">Font</h3>
               <div class="settings-section-content">
                 <div class="settings-row">
-                  <label class="settings-label">Font Family</label>
+                  <label class="settings-label" for="setting-font-family">Font Family</label>
                   <div class="settings-control">
-                    <select v-model="localSettings.fontFamily">
+                    <select id="setting-font-family" v-model="fontFamily">
                       <option v-for="font in fontOptions" :key="font" :value="font">
                         {{ font.split(',')[0].replace(/["']/g, '') }}
                       </option>
@@ -151,16 +156,22 @@ const onOverlayClick = (e: MouseEvent, onClose: () => void): void => {
                   </div>
                 </div>
                 <div class="settings-row">
-                  <label class="settings-label">Font Size</label>
+                  <label class="settings-label" for="setting-font-size">Font Size</label>
                   <div class="settings-control">
-                    <input v-model.number="localSettings.fontSize" type="number" min="8" max="32" />
+                    <input
+                      id="setting-font-size"
+                      v-model.number="fontSize"
+                      type="number"
+                      min="8"
+                      max="32"
+                    />
                   </div>
                 </div>
                 <div class="settings-row">
-                  <label class="settings-label">Word Wrap</label>
+                  <label class="settings-label" for="setting-wrap">Word Wrap</label>
                   <div class="settings-control">
-                    <input v-model="localSettings.wordWrap" type="checkbox" />
-                    <span class="settings-description">Enable word wrap in text areas</span>
+                    <input id="setting-wrap" v-model="wordWrap" type="checkbox" />
+                    <span class="settings-description">Wrap long lines in text areas</span>
                   </div>
                 </div>
               </div>
@@ -170,18 +181,21 @@ const onOverlayClick = (e: MouseEvent, onClose: () => void): void => {
               <h3 class="settings-section-title">Updates</h3>
               <div class="settings-section-content">
                 <div class="settings-row">
-                  <label class="settings-label">Enable Auto Update</label>
+                  <label class="settings-label" for="setting-auto-update">Enable auto update</label>
                   <div class="settings-control">
-                    <input v-model="localSettings.autoUpdate" type="checkbox" />
+                    <input id="setting-auto-update" v-model="autoUpdate" type="checkbox" />
                   </div>
                 </div>
                 <div class="settings-row">
-                  <label class="settings-label">Check for Updates on Startup</label>
+                  <label class="settings-label" for="setting-startup-update">
+                    Check for updates on startup
+                  </label>
                   <div class="settings-control">
                     <input
-                      v-model="localSettings.checkForUpdatesOnStartup"
+                      id="setting-startup-update"
+                      v-model="checkForUpdatesOnStartup"
                       type="checkbox"
-                      :disabled="!localSettings.autoUpdate"
+                      :disabled="!autoUpdate"
                     />
                   </div>
                 </div>
@@ -192,10 +206,13 @@ const onOverlayClick = (e: MouseEvent, onClose: () => void): void => {
               <h3 class="settings-section-title">Transformations</h3>
               <div class="settings-section-content">
                 <div class="settings-row">
-                  <label class="settings-label">Bcrypt Rounds (Cost Factor)</label>
+                  <label class="settings-label" for="setting-bcrypt">
+                    Bcrypt rounds (cost factor)
+                  </label>
                   <div class="settings-control">
                     <input
-                      v-model.number="localSettings.bcryptRounds"
+                      id="setting-bcrypt"
+                      v-model.number="bcryptRounds"
                       type="number"
                       min="1"
                       max="20"
@@ -205,8 +222,8 @@ const onOverlayClick = (e: MouseEvent, onClose: () => void): void => {
                 </div>
                 <div class="settings-info">
                   <p>
-                    Higher rounds provide stronger security but take longer to compute. The
-                    default value of 12 is a good balance between security and performance.
+                    Higher rounds provide stronger security but take longer to compute. The default
+                    value of 12 is a good balance between security and performance.
                   </p>
                 </div>
               </div>
@@ -216,8 +233,18 @@ const onOverlayClick = (e: MouseEvent, onClose: () => void): void => {
       </div>
 
       <div class="settings-footer">
-        <button @click="handleReset">Reset to Defaults</button>
-        <button @click="onClose">Close</button>
+        <button class="btn-secondary" @click="requestReset">Reset to defaults</button>
+        <button class="btn-primary" @click="onClose">Close</button>
+      </div>
+
+      <div v-if="showResetConfirm" class="settings-confirm-overlay" @click.self="cancelReset">
+        <div class="settings-confirm">
+          <p>Reset all settings to their default values?</p>
+          <div class="settings-confirm-actions">
+            <button class="btn-secondary" @click="cancelReset">Cancel</button>
+            <button class="btn-primary" @click="confirmReset">Reset</button>
+          </div>
+        </div>
       </div>
     </div>
   </div>

--- a/src/renderer/src/components/StatusBar.css
+++ b/src/renderer/src/components/StatusBar.css
@@ -8,8 +8,25 @@
   padding: 0 8px;
   font-size: 12px;
   color: var(--text);
+  flex-shrink: 0;
+}
+
+.status-left,
+.status-right {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  min-width: 0;
 }
 
 .status-item {
-  padding: 0 8px;
+  padding: 0 4px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.status-divider {
+  opacity: 0.4;
+  user-select: none;
 }

--- a/src/renderer/src/components/StatusBar.vue
+++ b/src/renderer/src/components/StatusBar.vue
@@ -2,19 +2,32 @@
 import { ref, computed, onMounted } from 'vue'
 import { storeToRefs } from 'pinia'
 import { useTabsStore } from '../stores/tabsStore'
+import { useTabsContentStore } from '../stores/tabsContentStore'
+import { useSettingsStore } from '../stores/settingsStore'
 import './StatusBar.css'
 
 const appVersion = ref<string>('')
 
 const tabsStore = useTabsStore()
-const { tabs, activeTabId, showHomePage } = storeToRefs(tabsStore)
+const { activeTabId, showHomePage } = storeToRefs(tabsStore)
 
-const currentTabName = computed((): string => {
-  if (showHomePage.value) return 'Home'
-  const activeTab = tabs.value.find((tab) => tab.id === activeTabId.value)
-  if (!activeTab) return 'Ready'
-  return activeTab.title
+const tabsContentStore = useTabsContentStore()
+const { tabsContent } = storeToRefs(tabsContentStore)
+
+const settingsStore = useSettingsStore()
+const { settings } = storeToRefs(settingsStore)
+
+const activeContent = computed(() => {
+  if (showHomePage.value || !activeTabId.value) return null
+  return tabsContent.value[activeTabId.value] ?? null
 })
+
+const inputCount = computed(() => activeContent.value?.inputText.length ?? 0)
+const outputCount = computed(() => activeContent.value?.outputText.length ?? 0)
+
+const formatCount = (n: number): string => {
+  return n === 1 ? '1 char' : `${n.toLocaleString()} chars`
+}
 
 onMounted(async () => {
   try {
@@ -28,7 +41,18 @@ onMounted(async () => {
 
 <template>
   <div class="status-bar">
-    <div class="status-item">{{ currentTabName }}</div>
-    <div class="status-item">v{{ appVersion }}</div>
+    <div class="status-left">
+      <template v-if="activeContent">
+        <span class="status-item">In: {{ formatCount(inputCount) }}</span>
+        <span class="status-divider">•</span>
+        <span class="status-item">Out: {{ formatCount(outputCount) }}</span>
+      </template>
+      <span v-else class="status-item">Ready</span>
+    </div>
+    <div class="status-right">
+      <span class="status-item">{{ settings.theme }}</span>
+      <span class="status-divider">•</span>
+      <span class="status-item">v{{ appVersion }}</span>
+    </div>
   </div>
 </template>

--- a/src/renderer/src/components/TabBar.css
+++ b/src/renderer/src/components/TabBar.css
@@ -135,6 +135,14 @@
   flex-shrink: 0;
 }
 
+.tabs-container[data-density='medium'] .tab {
+  max-width: 160px;
+}
+
+.tabs-container[data-density='compact'] .tab {
+  max-width: 120px;
+}
+
 .tab.active {
   background-color: var(--tabActiveBackground);
   color: var(--tabActiveText);
@@ -179,8 +187,14 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  border: none;
   border-radius: 50%;
+  background: transparent;
+  color: inherit;
+  padding: 0;
   font-size: 12px;
+  line-height: 1;
+  cursor: pointer;
   transition: all 0.15s ease;
   margin-left: 8px;
   opacity: 0.7;

--- a/src/renderer/src/components/TabBar.vue
+++ b/src/renderer/src/components/TabBar.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, watch, onMounted, onUnmounted, nextTick } from 'vue'
+import { ref, computed, watch, onMounted, onUnmounted, nextTick } from 'vue'
 import { storeToRefs } from 'pinia'
 import { useTabsStore } from '../stores/tabsStore'
 import './TabBar.css'
@@ -33,26 +33,16 @@ const contextMenuTabId = ref<string | null>(null)
 
 const showScrollButtons = ref<boolean>(false)
 
+const tabDensity = computed<'compact' | 'medium' | 'wide'>(() => {
+  if (tabs.value.length > 10) return 'compact'
+  if (tabs.value.length > 5) return 'medium'
+  return 'wide'
+})
+
 const checkScrollButtonsVisibility = (): void => {
   const container = tabsContainerRef.value
   if (!container) return
-
-  const shouldShowButtons = container.scrollWidth > container.clientWidth
-
-  const tabElements = container.querySelectorAll('.tab')
-  if (tabElements.length > 0) {
-    let maxWidth = '200px'
-    if (tabs.value.length > 10) {
-      maxWidth = '120px'
-    } else if (tabs.value.length > 5) {
-      maxWidth = '160px'
-    }
-    tabElements.forEach((tab) => {
-      ;(tab as HTMLElement).style.maxWidth = maxWidth
-    })
-  }
-
-  showScrollButtons.value = shouldShowButtons
+  showScrollButtons.value = container.scrollWidth > container.clientWidth
 }
 
 watch(
@@ -233,7 +223,7 @@ const handleDragEnd = (): void => {
 </script>
 
 <template>
-  <div class="tabs-container">
+  <div class="tabs-container" :data-density="tabDensity">
     <button
       class="home-button"
       :class="{ active: isHomeActive }"
@@ -278,7 +268,14 @@ const handleDragEnd = (): void => {
           @dragend="handleDragEnd"
         >
           <div class="tab-title">{{ tab.title }}</div>
-          <div class="tab-close" @click="handleCloseTab($event, tab.id)">✕</div>
+          <button
+            class="tab-close"
+            type="button"
+            :aria-label="`Close ${tab.title}`"
+            @click="handleCloseTab($event, tab.id)"
+          >
+            ✕
+          </button>
         </div>
       </div>
 
@@ -311,9 +308,7 @@ const handleDragEnd = (): void => {
         Close
       </div>
       <div class="context-menu-item" @click="handleCloseOtherTabs">Close Others</div>
-      <div class="context-menu-item" @click="handleCloseTabsToRight">
-        Close Tabs to the Right
-      </div>
+      <div class="context-menu-item" @click="handleCloseTabsToRight">Close Tabs to the Right</div>
       <div class="context-menu-item" @click="handleCloseAllTabs">Close All</div>
     </div>
   </div>

--- a/src/renderer/src/components/TitleBar.css
+++ b/src/renderer/src/components/TitleBar.css
@@ -7,18 +7,24 @@
   -webkit-app-region: drag;
   /* Make the title bar draggable */
   user-select: none;
+  position: relative;
 }
 
 .title-bar-drag-area {
   flex: 1;
   display: flex;
   align-items: center;
-  padding-left: 10px;
+  justify-content: center;
+  padding-left: 138px;
+  /* mirror the 3 × 46px window controls so the title stays optically centered */
 }
 
 .app-title {
   font-size: 12px;
   color: var(--titleBarText);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .window-controls {

--- a/src/renderer/src/components/TitleBar.vue
+++ b/src/renderer/src/components/TitleBar.vue
@@ -10,10 +10,10 @@ const tabsStore = useTabsStore()
 const { tabs, activeTabId, showHomePage } = storeToRefs(tabsStore)
 
 const appTitle = computed((): string => {
-  if (showHomePage.value) return 'Textonom - Home'
+  if (showHomePage.value) return 'Textonom'
   const activeTab = tabs.value.find((tab) => tab.id === activeTabId.value)
   if (!activeTab) return 'Textonom'
-  return `Textonom - ${activeTab.title}`
+  return `Textonom — ${activeTab.title}`
 })
 
 const checkMaximizedState = async (): Promise<void> => {
@@ -57,12 +57,16 @@ const closeWindow = (): void => {
       <div class="app-title">{{ appTitle }}</div>
     </div>
     <div class="window-controls">
-      <button class="window-control minimize" @click="minimizeWindow">
+      <button class="window-control minimize" aria-label="Minimize window" @click="minimizeWindow">
         <svg width="10" height="1" viewBox="0 0 10 1">
           <path d="M0 0h10v1H0z" fill="currentColor" />
         </svg>
       </button>
-      <button class="window-control maximize" @click="toggleMaximize">
+      <button
+        class="window-control maximize"
+        :aria-label="isMaximized ? 'Restore window' : 'Maximize window'"
+        @click="toggleMaximize"
+      >
         <svg v-if="isMaximized" width="10" height="10" viewBox="0 0 10 10">
           <path d="M0 0v10h10V0H0zm1 1h8v8H1V1z" fill="currentColor" />
         </svg>
@@ -70,12 +74,9 @@ const closeWindow = (): void => {
           <path d="M0 0v10h10V0H0zm9 9H1V1h8v8z" fill="currentColor" />
         </svg>
       </button>
-      <button class="window-control close" @click="closeWindow">
+      <button class="window-control close" aria-label="Close window" @click="closeWindow">
         <svg width="10" height="10" viewBox="0 0 10 10">
-          <path
-            d="M1 0L0 1l4 4-4 4 1 1 4-4 4 4 1-1-4-4 4-4-1-1-4 4-4-4z"
-            fill="currentColor"
-          />
+          <path d="M1 0L0 1l4 4-4 4 1 1 4-4 4 4 1-1-4-4 4-4-1-1-4 4-4-4z" fill="currentColor" />
         </svg>
       </button>
     </div>

--- a/src/renderer/src/components/UpdateNotification.vue
+++ b/src/renderer/src/components/UpdateNotification.vue
@@ -133,10 +133,10 @@ onMounted(() => {
     <div class="update-notification-content">
       <div class="update-notification-header">
         <h3>Checking for updates</h3>
-        <button class="close-button" @click="closeNotification">✕</button>
+        <button class="close-button" aria-label="Close" @click="closeNotification">✕</button>
       </div>
       <div class="update-notification-body">
-        <p>In progress...</p>
+        <p>Looking for a newer version…</p>
       </div>
     </div>
   </div>
@@ -147,11 +147,11 @@ onMounted(() => {
   >
     <div class="update-notification-content">
       <div class="update-notification-header">
-        <h3>Updates check completed</h3>
-        <button class="close-button" @click="closeNotification">✕</button>
+        <h3>Update check complete</h3>
+        <button class="close-button" aria-label="Close" @click="closeNotification">✕</button>
       </div>
       <div class="update-notification-body">
-        <p>You are using latest version</p>
+        <p>You're already on the latest version.</p>
       </div>
     </div>
   </div>
@@ -159,8 +159,8 @@ onMounted(() => {
   <div v-else-if="showUpdateAvailableNotification" class="update-notification">
     <div class="update-notification-content">
       <div class="update-notification-header">
-        <h3>Update Available</h3>
-        <button class="close-button" @click="closeNotification">✕</button>
+        <h3>Update available</h3>
+        <button class="close-button" aria-label="Close" @click="closeNotification">✕</button>
       </div>
       <div class="update-notification-body">
         <p>A new version ({{ updateInfo?.version }}) is available.</p>
@@ -176,7 +176,7 @@ onMounted(() => {
             {{ downloadButtonText }}
           </button>
           <button v-else @click="installUpdate">Install</button>
-          <button @click="closeNotification">Remind Me Later</button>
+          <button @click="closeNotification">Close</button>
         </div>
       </div>
     </div>
@@ -185,8 +185,8 @@ onMounted(() => {
   <div v-else-if="show" class="update-notification">
     <div class="update-notification-content">
       <div class="update-notification-header">
-        <h2>Software Update</h2>
-        <button class="close-button" @click="onClose">✕</button>
+        <h2>Update</h2>
+        <button class="close-button" aria-label="Close" @click="onClose">✕</button>
       </div>
 
       <div class="update-notification-body">

--- a/src/renderer/src/components/transformations/BaseTransformationPage.vue
+++ b/src/renderer/src/components/transformations/BaseTransformationPage.vue
@@ -23,16 +23,17 @@ const outputText = ref(initialContent.outputText)
 const paramValues = ref<TransformationParamValues>(initialContent.paramValues)
 const isTransforming = ref(false)
 
+// Show the spinner only if the transform takes long enough that the eye notices.
+const SPINNER_THRESHOLD_MS = 150
+
 const applyTransformation = async (): Promise<void> => {
   if (!inputText.value) return
-  isTransforming.value = true
+  const spinnerTimer = setTimeout(() => {
+    isTransforming.value = true
+  }, SPINNER_THRESHOLD_MS)
 
   try {
-    const result = await props.transformFunction(inputText.value, paramValues.value)
-    outputText.value = result
-    setTimeout(() => {
-      isTransforming.value = false
-    }, 100)
+    outputText.value = await props.transformFunction(inputText.value, paramValues.value)
   } catch (error) {
     console.error('Transformation error:', error)
     if (error instanceof Error) {
@@ -42,6 +43,8 @@ const applyTransformation = async (): Promise<void> => {
     } else {
       outputText.value = 'An unknown error occurred during transformation'
     }
+  } finally {
+    clearTimeout(spinnerTimer)
     isTransforming.value = false
   }
 }
@@ -57,7 +60,13 @@ const copyOutput = async (): Promise<void> => {
     await navigator.clipboard.writeText(outputText.value)
   } catch (error) {
     console.error('Failed to copy to clipboard:', error)
-    alert('Failed to copy to clipboard. Please try again or copy manually.')
+  }
+}
+
+const handleInputKeydown = (e: KeyboardEvent): void => {
+  if ((e.ctrlKey || e.metaKey) && e.key === 'Enter') {
+    e.preventDefault()
+    applyTransformation()
   }
 }
 
@@ -95,6 +104,7 @@ watch(
             class="transformation-textarea"
             :placeholder="inputPlaceholder"
             spellcheck="false"
+            @keydown="handleInputKeydown"
           ></textarea>
         </div>
       </div>
@@ -109,10 +119,10 @@ watch(
         </button>
         <button
           class="action-button clear-button"
-          :disabled="isTransforming || !inputText"
+          :disabled="isTransforming || (!inputText && !outputText)"
           @click="clearInput"
         >
-          Clear Input
+          Clear
         </button>
         <button
           class="action-button copy-button"

--- a/src/renderer/src/components/transformations/HmacHashPage.vue
+++ b/src/renderer/src/components/transformations/HmacHashPage.vue
@@ -25,19 +25,16 @@ const applyTransformation = async (): Promise<void> => {
 
   isTransforming.value = true
   try {
-    const result = await hmacHash(inputText.value, {
+    outputText.value = await hmacHash(inputText.value, {
       key: secretKey.value,
       algorithm: algorithm.value
     })
-    outputText.value = result
-    setTimeout(() => {
-      isTransforming.value = false
-    }, 100)
   } catch (error) {
     console.error('Transformation error:', error)
     if (error instanceof Error) outputText.value = `Error: ${error.message}`
     else if (typeof error === 'string') outputText.value = `Error: ${error}`
     else outputText.value = 'An unknown error occurred during transformation'
+  } finally {
     isTransforming.value = false
   }
 }
@@ -53,7 +50,13 @@ const copyOutput = async (): Promise<void> => {
     await navigator.clipboard.writeText(outputText.value)
   } catch (error) {
     console.error('Failed to copy to clipboard:', error)
-    alert('Failed to copy to clipboard. Please try again or copy manually.')
+  }
+}
+
+const handleKeydown = (e: KeyboardEvent): void => {
+  if ((e.ctrlKey || e.metaKey) && e.key === 'Enter') {
+    e.preventDefault()
+    applyTransformation()
   }
 }
 
@@ -75,6 +78,32 @@ watch([inputText, outputText, secretKey, algorithm], () => {
       </p>
     </div>
 
+    <div class="parameters-container">
+      <div class="parameter">
+        <label for="hmac-secret-key">Secret Key</label>
+        <input
+          id="hmac-secret-key"
+          v-model="secretKey"
+          type="text"
+          class="parameter-input"
+          :disabled="isTransforming"
+          placeholder="Enter secret key"
+        />
+      </div>
+      <div class="parameter">
+        <label for="hmac-algorithm">Algorithm</label>
+        <select
+          id="hmac-algorithm"
+          v-model="algorithm"
+          class="parameter-input"
+          :disabled="isTransforming"
+        >
+          <option value="SHA256">SHA-256</option>
+          <option value="SHA512">SHA-512</option>
+        </select>
+      </div>
+    </div>
+
     <div class="transformation-content">
       <div class="textarea-container">
         <label for="input-textarea">Input</label>
@@ -85,37 +114,12 @@ watch([inputText, outputText, secretKey, algorithm], () => {
             class="transformation-textarea"
             placeholder="Enter text to hash..."
             spellcheck="false"
+            @keydown="handleKeydown"
           ></textarea>
         </div>
       </div>
 
       <div class="actions-container">
-        <div class="parameters-container">
-          <div class="parameter">
-            <label for="secret-key-input">Secret Key</label>
-            <input
-              id="secret-key-input"
-              v-model="secretKey"
-              type="text"
-              class="parameter-input"
-              :disabled="isTransforming"
-              placeholder="Enter secret key"
-            />
-          </div>
-          <div class="parameter">
-            <label for="algorithm-select">Algorithm</label>
-            <select
-              id="algorithm-select"
-              v-model="algorithm"
-              class="parameter-input"
-              :disabled="isTransforming"
-            >
-              <option value="SHA256">SHA-256</option>
-              <option value="SHA512">SHA-512</option>
-            </select>
-          </div>
-        </div>
-
         <button
           class="action-button transform-button"
           :disabled="isTransforming"
@@ -125,10 +129,10 @@ watch([inputText, outputText, secretKey, algorithm], () => {
         </button>
         <button
           class="action-button clear-button"
-          :disabled="isTransforming || !inputText"
+          :disabled="isTransforming || (!inputText && !outputText)"
           @click="clearInput"
         >
-          Clear Input
+          Clear
         </button>
         <button
           class="action-button copy-button"

--- a/src/renderer/src/stores/electronStorage.ts
+++ b/src/renderer/src/stores/electronStorage.ts
@@ -37,7 +37,10 @@ interface PersistOptions<T> {
   hydrate: (data: T) => void
 }
 
-export const setupPersistence = <T>(opts: PersistOptions<T>, watcher: (cb: () => void) => void): void => {
+export const setupPersistence = <T>(
+  opts: PersistOptions<T>,
+  watcher: (cb: () => void) => void
+): void => {
   const storage = createElectronStorage(opts.key)
 
   void (async (): Promise<void> => {

--- a/src/renderer/src/stores/settingsStore.ts
+++ b/src/renderer/src/stores/settingsStore.ts
@@ -13,7 +13,7 @@ export interface Settings {
   wordWrap: boolean
 }
 
-const defaultSettings: Settings = {
+export const defaultSettings: Settings = {
   theme: 'cyberpunk',
   fontSize: 14,
   fontFamily: "Consolas, 'Courier New', monospace",

--- a/src/renderer/src/styles/global.css
+++ b/src/renderer/src/styles/global.css
@@ -12,6 +12,7 @@
   --surface: #343a40;
   --surfaceHover: #495057;
   --text: #f8f9fa;
+  --textSecondary: #adb5bd;
   --border: #495057;
   --divider: #343a40;
   --error: #dc3545;
@@ -150,6 +151,19 @@ input:focus,
 select:focus,
 textarea:focus {
   border-color: var(--primary);
+}
+
+:focus-visible {
+  outline: 2px solid var(--primary);
+  outline-offset: 2px;
+}
+
+input:focus-visible,
+select:focus-visible,
+textarea:focus-visible {
+  outline: none;
+  border-color: var(--primary);
+  box-shadow: 0 0 0 2px rgba(var(--primaryRgb), 0.35);
 }
 
 /* CRT Effect for Turbo Mode */

--- a/src/renderer/src/styles/themes.ts
+++ b/src/renderer/src/styles/themes.ts
@@ -15,6 +15,7 @@ interface Theme {
   surface: string
   surfaceHover: string
   text: string
+  textSecondary: string
   border: string
   divider: string
   error: string
@@ -52,6 +53,7 @@ export const lightTheme: Theme = {
   surface: '#f8f9fa',
   surfaceHover: '#e9ecef',
   text: '#212529',
+  textSecondary: '#6c757d',
   border: '#dee2e6',
   divider: '#e9ecef',
   error: '#dc3545',
@@ -89,6 +91,7 @@ export const darkTheme: Theme = {
   surface: '#343a40',
   surfaceHover: '#495057',
   text: '#f8f9fa',
+  textSecondary: '#adb5bd',
   border: '#495057',
   divider: '#343a40',
   error: '#dc3545',
@@ -125,7 +128,8 @@ export const cyberpunkTheme: Theme = {
   background: '#0a0a16', // Dark blue-black
   surface: '#1a1a2e', // Dark blue
   surfaceHover: '#2a2a4e', // Lighter blue
-  text: '#00ffff', // Cyan
+  text: '#d8f3ff', // Soft cyan-tinted white for body copy
+  textSecondary: '#00ffff', // Cyan kept as accent
   border: '#ff00ff', // Magenta
   divider: '#1a1a2e', // Dark blue
   error: '#ff0055', // Neon red


### PR DESCRIPTION
## Summary

A focused polish pass across copy, layout, accessibility, and theming — no behavioral changes to any transformation logic.

### Copy & docs
- Update-notification copy reworded for grammar/consistency ("Update check complete", "You're already on the latest version", consistent "Update" heading)
- About license corrected to **MIT** (was incorrectly listed as Apache 2.0)
- About feature list now generated from the transformation registry — no more stale list
- README and AGENTS updated to reflect the **Vue 3 + Pinia** stack (was still describing React + Zustand)
- "Clear Input" → "Clear" since it clears both fields
- Title bar shows just "Textonom" on Home; "Textonom — <tab>" elsewhere

### Layout
- Settings rows use a `220px / 1fr` grid so inputs line up across all sections (previously each row's input edge sat at a different x)
- Removed the sticky-with-`overflow:hidden` conflict on the section title that prevented sticking
- Reset uses an in-app, theme-correct confirm dialog instead of `window.confirm` (which broke the cyberpunk theme)
- Reset reuses the store's exported `defaultSettings` (no more duplicated default values to drift)
- Home cards: single `.transformation-card-content` padding rule, with reserved right-padding for the "✓ Open" badge so long titles ("Markdown to HTML", "JavaScript Formatter") no longer collide with the badge
- Title bar centers the app title (mirroring the 138px window-controls width)
- Status bar shows In/Out char counts + theme + version instead of duplicating the title-bar tab name

### Accessibility
- All Settings inputs now have associated `<label for>` / `id` pairs (clicking labels toggles checkboxes)
- Window-control, tab-close, and overlay close buttons get `aria-label`s
- Tab close converted from a `<div>` to a real `<button>`
- Home cards are keyboard-activatable (Enter/Space) with `aria-pressed` and a focus-visible ring
- Global `:focus-visible` outline and a focus ring on inputs

### Theming
- New `--textSecondary` token in all themes (was referenced in CSS but never defined)
- Cyberpunk body text softened to `#d8f3ff`; cyan stays as accent — long copy is now readable
- Settings footer uses explicit `.btn-primary` / `.btn-secondary` instead of `:first-child` rules that color-shifted per theme

### UX
- **Ctrl/Cmd+K** focuses the home search box
- **Ctrl/Cmd+Enter** triggers the transform from the input textarea
- `BaseTransformationPage` shows the spinner only after 150ms — instant transforms no longer flash a loader (also removes the artificial 100ms post-transform delay)

### Tabs
- Tab density (compact/medium/wide) is a `data-density` attribute; CSS drives max-width per density. Removes per-render imperative DOM mutation that caused visible reflow
- Tab close is a real `<button>` with an `aria-label`

## Test plan
- [ ] `npm run type-check` — passes
- [ ] `npm run lint` — only pre-existing v-html warnings remain
- [ ] `npm run build` — passes
- [ ] Manually exercise: open multiple tabs, search on Home with Ctrl+K, transform with Ctrl+Enter, open Settings → reset, switch themes (light/dark/cyberpunk), check the about modal, trigger an update check
- [ ] Verify Home card "✓ Open" badge no longer overlaps long titles
- [ ] Verify Settings inputs align across Theme/Font/Updates/Transformations sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)